### PR TITLE
Chain explosions and fiery click effect; tune density toward ~50 taps

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -10,13 +10,19 @@ const EXPLOSION_RADIUS = HEAD_SIZE * 2.2;
 let heads = [];
 let particles = [];
 let clickEffects = [];
+let slices = [];
 let cursorTrail = []; // Stores {x, y, life}
 let mouse = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+let prevMouse = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
 let audioCtx = null;
 let isUnlocked = false;
 
 let scareTimer = 0;
 const SCARE_DURATION = 40;
+const SLICE_INTERVAL = 60;
+let pointerDown = false;
+let lastSliceTime = 0;
+let hadSliceSinceDown = false;
 
 const colors = [null, '#111111', '#ffccaa', '#ffffff', '#333333'];
 
@@ -62,6 +68,30 @@ function playExplosionSound() {
     } catch (e) { }
 }
 
+function playSliceSound() {
+    try {
+        if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        if (audioCtx.state === 'suspended') audioCtx.resume();
+
+        const now = audioCtx.currentTime;
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(1200, now);
+        osc.frequency.exponentialRampToValueAtTime(180, now + 0.12);
+
+        gain.gain.setValueAtTime(0.001, now);
+        gain.gain.linearRampToValueAtTime(0.25, now + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.18);
+
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+
+        osc.start(now);
+        osc.stop(now + 0.2);
+    } catch (e) { }
+}
 class Head {
     constructor(x, y) {
         this.size = HEAD_SIZE;
@@ -178,6 +208,58 @@ class ClickEffect {
         ctx.strokeStyle = `rgba(255, 200, 80, ${this.life})`;
         ctx.lineWidth = 2;
         ctx.stroke();
+    }
+}
+
+class SlicePiece {
+    constructor(cx, cy, size, faceAngle, sliceAngle, side) {
+        this.cx = cx;
+        this.cy = cy;
+        this.size = size;
+        this.faceAngle = faceAngle;
+        this.sliceAngle = sliceAngle;
+        this.side = side;
+        this.life = 1.0;
+
+        const normal = sliceAngle + Math.PI / 2;
+        const speed = 3 + Math.random() * 2;
+        this.vx = Math.cos(normal) * speed * side + (Math.random() - 0.5) * 1.2;
+        this.vy = Math.sin(normal) * speed * side + 1.2;
+        this.rot = (Math.random() * 0.4 + 0.2) * side;
+    }
+
+    update() {
+        this.cx += this.vx;
+        this.cy += this.vy;
+        this.rot += 0.02 * this.side;
+        this.life -= 0.02;
+    }
+
+    draw() {
+        const img = (scareTimer > 0) ? scaredImage : headImage;
+        if (!img.complete) return;
+
+        ctx.save();
+        ctx.globalAlpha = Math.max(0, this.life);
+        ctx.translate(this.cx, this.cy);
+        ctx.rotate(this.faceAngle + this.rot);
+
+        const sliceAngleRel = this.sliceAngle - this.faceAngle;
+        ctx.rotate(sliceAngleRel);
+        ctx.beginPath();
+        if (this.side > 0) {
+            ctx.rect(-this.size, 0, this.size * 2, this.size);
+        } else {
+            ctx.rect(-this.size, -this.size, this.size * 2, this.size);
+        }
+        ctx.clip();
+        ctx.rotate(-sliceAngleRel);
+
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(img, -this.size / 2, -this.size / 2, this.size, this.size);
+
+        ctx.restore();
+        ctx.globalAlpha = 1.0;
     }
 }
 
@@ -308,12 +390,21 @@ function animate() {
         }
     }
 
+    for (let i = slices.length - 1; i >= 0; i--) {
+        slices[i].update();
+        slices[i].draw();
+        if (slices[i].life <= 0) {
+            slices.splice(i, 1);
+        }
+    }
+
     drawCursor();
 
     requestAnimationFrame(animate);
 }
 
 function handleInput(e, isClick) {
+    const now = performance.now();
     let cx, cy;
 
     if (e.type === 'touchend') {
@@ -329,11 +420,16 @@ function handleInput(e, isClick) {
         cy = e.clientY;
     }
 
+    prevMouse.x = mouse.x;
+    prevMouse.y = mouse.y;
     mouse.x = cx;
     mouse.y = cy;
 
     // isClick is true for mousedown and touchend
     if (isClick && !isUnlocked) {
+        if (hadSliceSinceDown) {
+            return;
+        }
         // Prevent default on touchend to avoid ghost mouse clicks
         if (e.type === 'touchend') {
             e.preventDefault();
@@ -370,6 +466,26 @@ function handleInput(e, isClick) {
         }
 
         checkWinCondition();
+    }
+
+    if (pointerDown && !isClick && !isUnlocked) {
+        const dx = mouse.x - prevMouse.x;
+        const dy = mouse.y - prevMouse.y;
+        const moveDist = Math.hypot(dx, dy);
+        if (moveDist > 2 && now - lastSliceTime >= SLICE_INTERVAL) {
+            for (let i = heads.length - 1; i >= 0; i--) {
+                if (heads[i].isHit(cx, cy)) {
+                    const sliceAngle = Math.atan2(dy, dx);
+                    triggerSlice(heads[i], sliceAngle);
+                    playSliceSound();
+                    scareTimer = SCARE_DURATION;
+                    lastSliceTime = now;
+                    hadSliceSinceDown = true;
+                    break;
+                }
+            }
+            checkWinCondition();
+        }
     }
 }
 
@@ -427,10 +543,39 @@ function triggerExplosion(head) {
     removed.forEach(explode);
 }
 
+function triggerSlice(head, sliceAngle) {
+    const centerX = head.x + head.size / 2;
+    const centerY = head.y + head.size / 2;
+    const faceAngle = Math.atan2(mouse.y - centerY, mouse.x - centerX);
+
+    const index = heads.indexOf(head);
+    if (index !== -1) {
+        heads.splice(index, 1);
+    }
+
+    slices.push(new SlicePiece(centerX, centerY, head.size, faceAngle, sliceAngle, 1));
+    slices.push(new SlicePiece(centerX, centerY, head.size, faceAngle, sliceAngle, -1));
+}
+
 window.addEventListener('resize', resize);
 window.addEventListener('scroll', updateButtonPositions); // Scroll might shift relative positions
 window.addEventListener('mousemove', e => handleInput(e, false));
-window.addEventListener('mousedown', e => handleInput(e, true));
+window.addEventListener('mousedown', e => {
+    pointerDown = true;
+    hadSliceSinceDown = false;
+    handleInput(e, true);
+});
+window.addEventListener('mouseup', () => {
+    pointerDown = false;
+});
+window.addEventListener('mouseleave', () => {
+    pointerDown = false;
+});
+window.addEventListener('touchstart', e => {
+    pointerDown = true;
+    hadSliceSinceDown = false;
+    handleInput(e, false);
+}, { passive: false });
 window.addEventListener('touchmove', e => {
     // Prevent scrolling or zooming while playing
     if (!isUnlocked) e.preventDefault();
@@ -438,7 +583,11 @@ window.addEventListener('touchmove', e => {
 }, { passive: false });
 // Switch to touchend for clicking
 window.addEventListener('touchend', e => {
+    pointerDown = false;
     handleInput(e, true);
 }, { passive: false });
+window.addEventListener('touchcancel', () => {
+    pointerDown = false;
+}, { passive: true });
 
 init();

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -4,10 +4,12 @@ const ui = document.getElementById('ui');
 
 const HEAD_SIZE = 48;
 const GRID_SPACING = 80;
-const MAX_HEADS = 100;
+const TARGET_TAPS = 50;
+const EXPLOSION_RADIUS = HEAD_SIZE * 2.2;
 
 let heads = [];
 let particles = [];
+let clickEffects = [];
 let cursorTrail = []; // Stores {x, y, life}
 let mouse = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
 let audioCtx = null;
@@ -139,6 +141,46 @@ class Particle {
     }
 }
 
+class ClickEffect {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.life = 1.0;
+        this.radius = 10;
+    }
+
+    update() {
+        this.radius += 6;
+        this.life -= 0.06;
+    }
+
+    draw() {
+        const outerRadius = this.radius + 18;
+        const gradient = ctx.createRadialGradient(
+            this.x,
+            this.y,
+            this.radius * 0.2,
+            this.x,
+            this.y,
+            outerRadius
+        );
+        gradient.addColorStop(0, `rgba(255, 230, 120, ${this.life * 0.9})`);
+        gradient.addColorStop(0.6, `rgba(255, 120, 40, ${this.life * 0.8})`);
+        gradient.addColorStop(1, 'rgba(255, 60, 0, 0)');
+
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, outerRadius, 0, Math.PI * 2);
+        ctx.fillStyle = gradient;
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+        ctx.strokeStyle = `rgba(255, 200, 80, ${this.life})`;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+    }
+}
+
 function init() {
     resize();
     createGrid();
@@ -151,8 +193,8 @@ function createGrid() {
 
     heads = [];
     const area = canvas.width * canvas.height;
-    const maxSpacing = Math.sqrt(area / MAX_HEADS);
-    const spacing = Math.max(GRID_SPACING, maxSpacing);
+    const densityBoost = Math.sqrt(area / (TARGET_TAPS * 1.4));
+    const spacing = Math.min(GRID_SPACING, densityBoost);
     const cols = Math.ceil(canvas.width / spacing);
     const rows = Math.ceil(canvas.height / spacing);
 
@@ -258,6 +300,14 @@ function animate() {
         }
     }
 
+    for (let i = clickEffects.length - 1; i >= 0; i--) {
+        clickEffects[i].update();
+        clickEffects[i].draw();
+        if (clickEffects[i].life <= 0) {
+            clickEffects.splice(i, 1);
+        }
+    }
+
     drawCursor();
 
     requestAnimationFrame(animate);
@@ -293,8 +343,7 @@ function handleInput(e, isClick) {
         // Priority 1: Click on a Face
         for (let i = heads.length - 1; i >= 0; i--) {
             if (heads[i].isHit(cx, cy)) {
-                explode(heads[i]);
-                heads.splice(i, 1);
+                triggerExplosion(heads[i]);
                 playExplosionSound();
                 scareTimer = SCARE_DURATION;
                 hit = true;
@@ -348,6 +397,34 @@ function explode(head) {
         const c = colors[Math.floor(Math.random() * colors.length)];
         particles.push(new Particle(centerX, centerY, c || '#fff'));
     }
+}
+
+function triggerExplosion(head) {
+    const centerX = head.x + head.size / 2;
+    const centerY = head.y + head.size / 2;
+    clickEffects.push(new ClickEffect(centerX, centerY));
+
+    const removed = [];
+    for (let i = heads.length - 1; i >= 0; i--) {
+        const target = heads[i];
+        const tx = target.x + target.size / 2;
+        const ty = target.y + target.size / 2;
+        const dist = Math.hypot(tx - centerX, ty - centerY);
+        if (dist <= EXPLOSION_RADIUS) {
+            removed.push(target);
+            heads.splice(i, 1);
+        }
+    }
+
+    if (!removed.includes(head)) {
+        const index = heads.indexOf(head);
+        if (index !== -1) {
+            heads.splice(index, 1);
+        }
+        removed.push(head);
+    }
+
+    removed.forEach(explode);
 }
 
 window.addEventListener('resize', resize);


### PR DESCRIPTION
### Motivation
- Remove the hard cap on number of heads and tune the spawn density so the game targets about `50` taps to win.
- Make single taps more impactful by having one exploded head clear nearby heads to reduce required user input.
- Add a visual feedback (fiery click pulse) so detonations are more satisfying and obvious.
- Keep existing particle explosions and sound while improving the interaction feel.

### Description
- Replaced `MAX_HEADS` with `TARGET_TAPS` and added `EXPLOSION_RADIUS` to control chain removal radius and tuning of density.
- Changed grid spacing calculation to use a `densityBoost` toward `TARGET_TAPS` and compute `spacing` with `Math.min` so more heads can appear without a hard cap.
- Added a `ClickEffect` class and `clickEffects` array to render a radial fire/pulse animation on clicks, and integrated it into the `animate` loop.
- Implemented `triggerExplosion(head)` which spawns a `ClickEffect`, removes all heads within `EXPLOSION_RADIUS`, calls existing `explode()` to spawn particles for each removed head, and updated `handleInput` to call `triggerExplosion` instead of directly calling `explode` + manual splice.

### Testing
- Started a local static server with `python -m http.server 8000` and ran an automated Playwright script to open the page, perform a click, and capture a screenshot at `artifacts/explosion-effect.png` (visual smoke test).
- The Playwright run completed and produced the screenshot artifact indicating the click effect rendered.
- No automated unit tests exist for this static site; changes were validated via the visual/interaction smoke test above.
- Commit was created for the updated `assets/js/script.js` file after verification of the visual effect.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b85910298832094553dbde25dc3b5)